### PR TITLE
Fix issue getting base URL for flutter archives

### DIFF
--- a/src/install/index.js
+++ b/src/install/index.js
@@ -48,7 +48,7 @@ function findLatestSdkInformation(channel, arch) {
         var currentHash = json.current_release[channel];
         var current = json.releases.find((item) => item.hash === currentHash);
         return {
-            downloadUrl: body.base_url + '/' + current.archive,
+            downloadUrl: json.base_url + '/' + current.archive,
             version: channel + '-' + current.version.substring(1)
         };
     });

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -36,7 +36,7 @@ async function findLatestSdkInformation(channel: string, arch: string): Promise<
     var currentHash = json.current_release[channel];
     var current = json.releases.find((item: { hash: any; }) => item.hash === currentHash);
     return {
-        downloadUrl: body.base_url + '/' + current.archive,
+        downloadUrl: json.base_url + '/' + current.archive,
         version: channel + '-' + current.version.substring(1)
     };
 }


### PR DESCRIPTION
Currently it's not working due to the body it's a string rather than an object. This PR fix that.